### PR TITLE
Settings for Network Accelerator and Parallel Highway Assignment

### DIFF
--- a/tm2py_utils/config/develop/model_config.toml
+++ b/tm2py_utils/config/develop/model_config.toml
@@ -48,8 +48,10 @@
     TNC_ZPV_factor = 0.7
     ctramp_hh_file = "ctramp_output/householdData_{iteration}.csv"
 	highway_maz_ctramp_output_file = "ctramp_output/auto_{period}_MAZ_AUTO_{number}_{period}.omx"
-    sample_rate_by_iteration = [0.05, 0.5 , 1.0, 0.02, 0.02,]
 
+    # sample rate by iteration
+    sample_rate_by_iteration = [0.15, 0.25, 0.50]
+	
     # demand matrices for assignment
     highway_demand_file = "demand_matrices/highway/household/TAZ_Demand_{period}_{iter}.omx"
     active_demand_file = "demand_matrices/active/nm_demand_{period}.omx"
@@ -509,8 +511,8 @@
     output_skim_path = "skim_matrices/highway"
     output_skim_filename_tmpl = "HWYSKM{time_period}_taz.omx"
     output_skim_matrixname_tmpl = "{time_period}_{mode}_{property}"
+    network_acceleration = false
     max_iterations = 100
-    network_acceleration = true
     # labels entire highway network (any of the classes) + MAZ connectors
     generic_highway_mode_code = "c"
     # include other MAZs to estimate density (pop+jobs*2.5)/acres for each MAZ
@@ -921,11 +923,13 @@
             source = "household"
             name = "WLK_TRN_KNR"
 
-[post_processor]
-    network_shapefile_path = "output_summaries/network_shapefile_{iteration}_{period}.shp"
-    boardings_by_segment_file_path = "output_summaries/boardings_by_segment_{iteration}_{period}.csv"
-    boardings_by_segment_geofile_path = "output_summaries/boardings_by_segment_{iteration}_{period}.shp"
 
+[post_processor]
+    network_shapefile_path = "output_summaries/Scenario_{period}/"
+    boardings_by_segment_file_path = "output_summaries/Scenario_{period}/transit_segments.csv"
+    boardings_by_segment_geofile_path = "output_summaries/boardings_by_segment_{period}.geojson"
+
+	
 [emme]
     num_processors = "MAX-1"
     num_processors_transit_skim = "32"
@@ -936,6 +940,20 @@
     active_south_database_path = "emme_project/Database_active_south/emmebank"
     transit_database_path = "emme_project/Database_transit/emmebank"
 
+    #[[emme.highway_distribution]]
+    #    time_periods = ["AM"]
+    #    num_processors = "MAX/3"
+    #[[emme.highway_distribution]]
+    #    time_periods = ["PM"]
+    #    num_processors = "MAX/3"
+    #[[emme.highway_distribution]]
+    #    time_periods = ["EA", "MD", "EV"]
+    #    num_processors = "MAX/3"	
+		
+    [[emme.highway_distribution]]
+        time_periods = ["EA", "AM", "MD", "PM", "EV"]
+        num_processors = "MAX-1"
+		
 # see [issue #5](https://github.com/BayAreaMetro/travel-model-two-config/issues/5) for documentation on assumptions
 [[highway.capclass_lookup]]
 	capclass = 0

--- a/tm2py_utils/config/develop/scenario_config.toml
+++ b/tm2py_utils/config/develop/scenario_config.toml
@@ -22,7 +22,7 @@
         "highway_maz_skim",
         "prepare_network_transit",
         "transit_assign", 
-        "transit_skim",
+        "transit_skim" 
     ]
     global_iteration_components = [
         "household",
@@ -30,15 +30,16 @@
         "truck",
         "highway_maz_assign",
         "highway",
-        #"drive_access_skims",
         "transit_assign",
         "transit_skim",
     ]
-    final_components = []
+    final_components = [
+	    "post_processor"
+    ]
     start_iteration = 0
     end_iteration = 3
 
 [warmstart]
     warmstart = true
-    use_warmstart_skim = false
-    use_warmstart_demand = true
+    use_warmstart_skim = true
+    use_warmstart_demand = false


### PR DESCRIPTION
The code changes to implement EMME's network acceleration and parallel highway assignment have been merged into tm2py develop branch in PR https://github.com/BayAreaMetro/tm2py/pull/167. **This PR here includes the corresponding model settings, which if missing, can cause the AM assignment to hang**, according to original comments from @lachlan-git : https://github.com/BayAreaMetro/tm2py/pull/167#issuecomment-2867494526 and https://github.com/BayAreaMetro/tm2py/pull/167#issuecomment-2877401896

Also suggest doing the follow:

- [ ] Default network acceleration to `False`, and highway period assignment to run sequentially. This is because we did not observe run time saving on a large machine.
- [ ] Add these settings to config checking, such as [this](https://github.com/BayAreaMetro/tm2py/blob/c495e0a5ca24585fccb88e7ea049fe0bf4c24f10/tm2py/config.py#L148-L156), so that they get caught in the beginning of the run.
- [ ] Make sure model runs are set up with these settings, i.e., is the Setup Model step pointing to the correct branch?

Fyi @Ennazus @AshishKuls @DavidOry 