### PR TITLE
Update maz assignment

### DIFF
--- a/tm2py_utils/config/2015-tm22-dev-sprint-04/model_config.toml
+++ b/tm2py_utils/config/2015-tm22-dev-sprint-04/model_config.toml
@@ -517,6 +517,9 @@
     area_type_buffer_dist_miles = 0.5
     # nodes at interchanges, for highway reliability calculation
     interchange_nodes_file = "inputs/hwy/interchange_nodes.csv"
+    # model ID to Emme node ID crosswalk written out in network build process
+    model_to_emme_node_id_xwalk = "emme_project/Database_highway/emme_drive_network_node_id_crosswalk.csv"
+    output_node_sequential_id_xwalk = "inputs/hwy/mtc_final_network_zone_seq.csv"
     # reliability
     reliability = true
     apply_msa_demand = true

--- a/tm2py_utils/config/2015-tm22-dev-sprint-04/model_config.toml
+++ b/tm2py_utils/config/2015-tm22-dev-sprint-04/model_config.toml
@@ -503,7 +503,7 @@
     # reliability
     reliability = true
     apply_msa_demand = true
-    # threshold (miles) where a drive trip is short enough to be moved to a taz
+    # threshold (miles) for maz assignment; when an auto trip distance is below the threshold, it will be assigned at the MAZ level instead of the TAZ level
     maz_drive_distance_threshold = 0.5
     [highway.tolls]
         file_path = "inputs/hwy/tolls.csv"

--- a/tm2py_utils/config/2015-tm22-dev-sprint-04/model_config.toml
+++ b/tm2py_utils/config/2015-tm22-dev-sprint-04/model_config.toml
@@ -60,35 +60,15 @@
         "single_tnc"=0.72
         "shared_tnc"=0.20
     [household.taxi_split]
-        "da"= 0.00
-        "sr2"= 0.53
-        "sr3"= 0.47
+        "sr2_hov"= 0.53
+        "sr3_hov"= 0.47
     [household.single_tnc_split]
-        "da"= 0.00
-        "sr2"= 0.53
-        "sr3"= 0.47
+        "sr2_hov"= 0.53
+        "sr3_hov"= 0.47
     [household.shared_tnc_split]
-        "da"= 0.00
-        "sr2"= 0.18
-        "sr3"= 0.82
-    [household.ctramp_mode_names]
-        1 = 'sov_gp'
-        2 = 'sov_pay'
-        3 = 'sr2_gp'
-        4 = 'sr2_hov'
-        5 = 'sr2_pay'
-        6 = 'sr3_gp'
-        7 = 'sr3_hov'
-        8 = 'sr3_pay'
-        9 = 'walk'
-        10 = 'bike'
-        11 = 'wlk'
-        12 = 'pnr'
-        13 = 'knr'
-        14 = 'knr'
-        15 = 'taxi'
-        16 = 'tnc'
-        17 = 'schlbus'
+        "sr2_hov"= 0.18
+        "sr3_hov"= 0.82
+   
 	[household.income_segment]
         enabled = false
         segment_suffixes = ["LowInc", "MedInc", "HighInc", "XHighInc"]
@@ -523,6 +503,8 @@
     # reliability
     reliability = true
     apply_msa_demand = true
+    # threshold (miles) where a drive trip is short enough to be moved to a taz
+    maz_drive_distance_threshold = 0.5
     [highway.tolls]
         file_path = "inputs/hwy/tolls.csv"
         src_vehicle_group_names = ["da", "s2",  "s3",  "vsm", "sml", "med", "lrg"]
@@ -545,16 +527,16 @@
             # based on ~= 5 miles @ 40 mph = 11
             #           = time + (0.6 / vot) * (dist * opcost)
             #           = 5 / 40 * 60 + (0.6 / 17.23) * (5 * 18.93)
-        demand_file = "demand_matrices/highway/maz_demand/auto_{period}_MAZ_AUTO_{number}_{period}_{iter}.omx"
+        demand_file = "demand_matrices/highway/maz_demand/MAZ_AUTO_{period}_{iter}.csv"
         [[highway.maz_to_maz.demand_county_groups]]
             number = 1
-            counties = ["San Francisco", "San Mateo", "Santa Clara"]
-        [[highway.maz_to_maz.demand_county_groups]]
-            number = 2
-            counties = ["Alameda", "Contra Costa"]
-        [[highway.maz_to_maz.demand_county_groups]]
-            number = 3
-            counties = ["Solano", "Napa", "Sonoma", "Marin"]
+            counties = ["San Francisco", "San Mateo", "Santa Clara", "Alameda", "Contra Costa", "Solano", "Napa", "Sonoma", "Marin"]
+        # [[highway.maz_to_maz.demand_county_groups]]
+        #     number = 2
+        #     counties = ["Alameda", "Contra Costa"]
+        # [[highway.maz_to_maz.demand_county_groups]]
+        #     number = 3
+        #     counties = ["Solano", "Napa", "Sonoma", "Marin"]
 
     [[highway.relative_gaps]]
         global_iteration = 0

--- a/tm2py_utils/config/2015-tm22-dev-sprint-04/scenario_config.toml
+++ b/tm2py_utils/config/2015-tm22-dev-sprint-04/scenario_config.toml
@@ -3,11 +3,9 @@
 ####################################
 
 [scenario]
-    name = "tm22-dev-sprint-03"
+    name = "tm22-dev-sprint-04"
     year = 2015
     verify = false
-    maz_landuse_file = "inputs/landuse/maz_data.csv"
-    zone_seq_file = "inputs/landuse/mtc_final_network_zone_seq.csv"
     landuse_file = "inputs/landuse/maz_data_withDensity.csv"
     landuse_index_column = "TAZ"
 
@@ -34,11 +32,17 @@
         "transit_assign",
         "transit_skim",
     ]
-    final_components = []
+    final_components = [
+        "post_processor",
+        "network_summary"
+    ]
     start_iteration = 0
     end_iteration = 3
 
 [warmstart]
     warmstart = true
-    use_warmstart_skim = false
+    use_warmstart_skim = fale
     use_warmstart_demand = true
+
+[slack_notifications]
+enabled = true

--- a/tm2py_utils/config/2015-tm22-dev-sprint-04/scenario_config.toml
+++ b/tm2py_utils/config/2015-tm22-dev-sprint-04/scenario_config.toml
@@ -28,7 +28,6 @@
         "truck",
         "highway_maz_assign",
         "highway",
-        #"drive_access_skims",
         "transit_assign",
         "transit_skim",
     ]
@@ -41,7 +40,7 @@
 
 [warmstart]
     warmstart = true
-    use_warmstart_skim = fale
+    use_warmstart_skim = false
     use_warmstart_demand = true
 
 [slack_notifications]

--- a/tm2py_utils/config/2023-tm22-dev-version-05/scenario_config.toml
+++ b/tm2py_utils/config/2023-tm22-dev-version-05/scenario_config.toml
@@ -6,7 +6,6 @@
     name = "2023-tm22-dev-version-05"
     year = 2023
     verify = false
-    maz_landuse_file = "inputs/landuse/maz_data.csv"
     zone_seq_file = "inputs/landuse/mtc_final_network_zone_seq.csv"
     landuse_file = "inputs/landuse/maz_data_withDensity.csv"
     landuse_index_column = "TAZ"

--- a/tm2py_utils/config/2023-tm22-dev-version-05/scenario_config.toml
+++ b/tm2py_utils/config/2023-tm22-dev-version-05/scenario_config.toml
@@ -6,7 +6,6 @@
     name = "2023-tm22-dev-version-05"
     year = 2023
     verify = false
-    zone_seq_file = "inputs/landuse/mtc_final_network_zone_seq.csv"
     landuse_file = "inputs/landuse/maz_data_withDensity.csv"
     landuse_index_column = "TAZ"
 
@@ -29,7 +28,6 @@
         "truck",
         "highway_maz_assign",
         "highway",
-        #"drive_access_skims",
         "transit_assign",
         "transit_skim",
     ]

--- a/tm2py_utils/summary/acceptance/canonical.py
+++ b/tm2py_utils/summary/acceptance/canonical.py
@@ -192,7 +192,7 @@ class Canonical:
         Returns:
             None
         """
-        in_file = self.scenario_dict["scenario"]["maz_landuse_file"]
+        in_file = self.scenario_dict["scenario"]["landuse_file"]
 
         logging.info(f"Reading {self.scenario_dir / in_file}")
         self.simulated_maz_data_df = pd.read_csv(self.scenario_dir / in_file)

--- a/tm2py_utils/summary/acceptance/canonical.py
+++ b/tm2py_utils/summary/acceptance/canonical.py
@@ -45,7 +45,7 @@ class Canonical:
             Set by: _read_standard_transit_to_survey_crosswalk()
         simulated_maz_data_df (pd.DataFrame): MAZ-level land use data with county and district IDs.
             Key columns: [MAZ_NODE, MAZ_SEQ, TAZ_NODE, TAZ_SEQ, DistID, CountyName] plus
-            land use variables from maz_landuse_file
+            land use variables from landuse_file
             Set by: _make_simulated_maz_data()
         taz_to_district_df (pd.DataFrame): TAZ to planning district mapping.
             Columns: [taz, district]

--- a/tm2py_utils/summary/acceptance/simulated.py
+++ b/tm2py_utils/summary/acceptance/simulated.py
@@ -388,7 +388,7 @@ class Simulated:
         temp = a_df["line_long"].str.split(pat="-", expand=True)
         a_df["LINE_ID"] = temp[0]
         a_df = a_df.rename(columns={"i_node": "INODE", "j_node": "JNODE"})
-        a_df = a_df[~(a_df["JNODE"] == "None")].reset_index().copy()
+        a_df = a_df[a_df["JNODE"].notna() & (a_df["JNODE"] != "None")].reset_index().copy()
         a_df["JNODE"] = a_df["JNODE"].astype("float").astype("Int64")
         df = a_df[["LINE_ID", "line", "INODE", "JNODE", "board"]]
 
@@ -696,7 +696,7 @@ class Simulated:
             names_df = self._get_station_names_from_standard_network(rail_nodes_df)
             logging.debug(f"names_df:\n{names_df}")
             if "level_0" in names_df.columns:
-                names_df = names_df.drop(columns=["level_0", "index"])
+                names_df = names_df.drop(columns=["level_0", "index"]).drop_duplicates()
             station_list = names_df.boarding.astype(str).unique().tolist()
 
             access_df = transit_df.copy()

--- a/tm2py_utils/summary/acceptance/simulated.py
+++ b/tm2py_utils/summary/acceptance/simulated.py
@@ -635,37 +635,6 @@ class Simulated:
 
         return
 
-    def _make_simulated_maz_data(self):
-        in_file = self.scenario_dir / self.scenario_dict["scenario"]["maz_landuse_file"]
-        logging.info(f"Reading {in_file}")
-        df = pd.read_csv(in_file)
-        logging.debug(f"df:\n{df}")
-
-        index_file = self.scenario_dir / "inputs/landuse/mtc_final_network_zone_seq.csv"
-        logging.info(f"Reading {index_file}")
-        index_df = pd.read_csv(index_file)
-        logging.debug(f"df:\n{df}")
-        join_df = index_df.rename(columns={"N": "MAZ_ORIGINAL"})[
-            ["MAZ_ORIGINAL", "MAZSEQ"]
-        ].copy()
-
-        self.simulated_maz_data_df = pd.merge(
-            df,
-            join_df,
-            how="left",
-            on="MAZ_ORIGINAL",
-        )
-
-        self._make_taz_district_crosswalk()
-
-        return
-
-    def _make_taz_district_crosswalk(self):
-        df = self.simulated_maz_data_df[["TAZ_ORIGINAL", "DistID"]].copy()
-        df = df.rename(columns={"TAZ_ORIGINAL": "taz", "DistID": "district"})
-        self.taz_to_district_df = df.drop_duplicates().reset_index(drop=True)
-
-        return
 
     def _reduce_simulated_rail_access_summaries(self):
         """Process rail station access mode summaries.


### PR DESCRIPTION
Updated model_config.toml to work with:

https://github.com/BayAreaMetro/tm2py/pull/215

testing completed in afformentioned PR.

This PR is intended to be additional changes on top of https://github.com/BayAreaMetro/tm2py-utils/pull/12

# Changes
household.rideshare_mode_split was updated to align with the most updated names

household.ctramp_mode_names was moved into the enum.py, which will be the source of truth for mode and mode codes into the future.

highway.maz_to_maz was updated to use a CSV as this is the intermediate format for maz assignment

